### PR TITLE
Debugging field formatting

### DIFF
--- a/meerkat_nest/resources/upload_data.py
+++ b/meerkat_nest/resources/upload_data.py
@@ -117,7 +117,7 @@ class UploadData(Resource):
 def upload_to_raw_data(data_entry):
     """
     Stores raw data in Meerkat Nest database
-
+    
     Returns:\n
         uuid for the PK of the raw data row\n
     """
@@ -165,7 +165,7 @@ def store_processed_data(data_entry):
 def process(data_entry):
     """
     Processes raw data and stores the processed data entry in in Meerkat Nest database
-
+    
     Returns:\n
         processed data_entry if processing was successful, False otherwise
     """
@@ -173,20 +173,11 @@ def process(data_entry):
     assert data_entry['content'] in ['form', 'record'], "Content not supported"
     assert data_entry['formId'] in config.country_config['tables'], "Form not supported"
 
-    logging.warning(
-        "-----Processing new data entry-----\n" + str(data_entry)
-    )
     processed_data_entry = restructure_aggregate_data(data_entry)
     processed_data_entry = process_patient_id(processed_data_entry)
     processed_data_entry = scramble_fields(processed_data_entry)
     processed_data_entry = hash_fields(processed_data_entry)
-    logging.warning(
-        "Formatting field keys on data entry:\n" + str(data_entry)
-    )
     processed_data_entry = format_field_keys(processed_data_entry)
-    logging.warning(
-        "Output from formatting field keys:\n" + str(data_entry)
-    )
     processed_data_entry = format_form_name(processed_data_entry)
 
     return processed_data_entry
@@ -195,7 +186,7 @@ def process(data_entry):
 def restructure_aggregate_data(data_entry):
     """
     Restructures data from aggregate JSON feed
-
+    
     Returns:\n
         restructured data entry
     """
@@ -241,7 +232,7 @@ def process_patient_id(data_entry):
 def scramble_fields(data_entry):
     """
     Scrambles fields in data entry based on configurations
-
+    
     Returns:\n
         data entry structure with scrambled fields
     """
@@ -279,14 +270,14 @@ def hash_fields(data_entry):
 def format_field_keys(data_entry):
     """
     Formats the field names in the data entry
-
+    
     Returns:\n
         data entry structure with formatted field namess
     """
 
     rename_fields = config.country_config.get('rename_fields',
                                               {}).get(data_entry['formId'], {})
-    character_replacements = config.country_config.get('replace_characters',
+    character_replacements = config.country_config.get('replace_characters', 
                                                        {}).get(data_entry['formId'], [])
     data_fields = data_entry['data'].keys()
 
@@ -294,20 +285,8 @@ def format_field_keys(data_entry):
     for characters in character_replacements:
         for key in data_fields:
             if characters[0] in key:
-                if 'pt.' in key:
-                    logging.warning(
-                        str(key) + " becomes " +
-                        str(key.replace(characters[0], characters[1]))
-                    )
-                data_entry['data'][
-                    key.replace(characters[0], characters[1])
-                ] = data_entry['data'][key]
+                data_entry['data'][key.replace(characters[0],characters[1])] = data_entry['data'][key]
                 data_entry['data'].pop(key)
-                if 'pt.' in key:
-                    logging.warning(
-                        data_entry['data'][key.replace(characters[0], characters[1])]
-                    )
-
 
     # Perform key replacements
     for key in rename_fields:

--- a/meerkat_nest/resources/upload_data.py
+++ b/meerkat_nest/resources/upload_data.py
@@ -117,7 +117,7 @@ class UploadData(Resource):
 def upload_to_raw_data(data_entry):
     """
     Stores raw data in Meerkat Nest database
-    
+
     Returns:\n
         uuid for the PK of the raw data row\n
     """
@@ -165,7 +165,7 @@ def store_processed_data(data_entry):
 def process(data_entry):
     """
     Processes raw data and stores the processed data entry in in Meerkat Nest database
-    
+
     Returns:\n
         processed data_entry if processing was successful, False otherwise
     """
@@ -173,11 +173,20 @@ def process(data_entry):
     assert data_entry['content'] in ['form', 'record'], "Content not supported"
     assert data_entry['formId'] in config.country_config['tables'], "Form not supported"
 
+    logging.warning(
+        "-----Processing new data entry-----\n" + str(data_entry)
+    )
     processed_data_entry = restructure_aggregate_data(data_entry)
     processed_data_entry = process_patient_id(processed_data_entry)
     processed_data_entry = scramble_fields(processed_data_entry)
     processed_data_entry = hash_fields(processed_data_entry)
+    logging.warning(
+        "Formatting field keys on data entry:\n" + str(data_entry)
+    )
     processed_data_entry = format_field_keys(processed_data_entry)
+    logging.warning(
+        "Output from formatting field keys:\n" + str(data_entry)
+    )
     processed_data_entry = format_form_name(processed_data_entry)
 
     return processed_data_entry
@@ -186,7 +195,7 @@ def process(data_entry):
 def restructure_aggregate_data(data_entry):
     """
     Restructures data from aggregate JSON feed
-    
+
     Returns:\n
         restructured data entry
     """
@@ -232,7 +241,7 @@ def process_patient_id(data_entry):
 def scramble_fields(data_entry):
     """
     Scrambles fields in data entry based on configurations
-    
+
     Returns:\n
         data entry structure with scrambled fields
     """
@@ -270,14 +279,14 @@ def hash_fields(data_entry):
 def format_field_keys(data_entry):
     """
     Formats the field names in the data entry
-    
+
     Returns:\n
         data entry structure with formatted field namess
     """
 
     rename_fields = config.country_config.get('rename_fields',
                                               {}).get(data_entry['formId'], {})
-    character_replacements = config.country_config.get('replace_characters', 
+    character_replacements = config.country_config.get('replace_characters',
                                                        {}).get(data_entry['formId'], [])
     data_fields = data_entry['data'].keys()
 
@@ -285,8 +294,20 @@ def format_field_keys(data_entry):
     for characters in character_replacements:
         for key in data_fields:
             if characters[0] in key:
-                data_entry['data'][key.replace(characters[0],characters[1])] = data_entry['data'][key]
+                if 'pt.' in key:
+                    logging.warning(
+                        str(key) + " becomes " +
+                        str(key.replace(characters[0], characters[1]))
+                    )
+                data_entry['data'][
+                    key.replace(characters[0], characters[1])
+                ] = data_entry['data'][key]
                 data_entry['data'].pop(key)
+                if 'pt.' in key:
+                    logging.warning(
+                        data_entry['data'][key.replace(characters[0], characters[1])]
+                    )
+
 
     # Perform key replacements
     for key in rename_fields:

--- a/meerkat_nest/resources/upload_data.py
+++ b/meerkat_nest/resources/upload_data.py
@@ -117,7 +117,7 @@ class UploadData(Resource):
 def upload_to_raw_data(data_entry):
     """
     Stores raw data in Meerkat Nest database
-    
+
     Returns:\n
         uuid for the PK of the raw data row\n
     """
@@ -165,7 +165,7 @@ def store_processed_data(data_entry):
 def process(data_entry):
     """
     Processes raw data and stores the processed data entry in in Meerkat Nest database
-    
+
     Returns:\n
         processed data_entry if processing was successful, False otherwise
     """
@@ -186,7 +186,7 @@ def process(data_entry):
 def restructure_aggregate_data(data_entry):
     """
     Restructures data from aggregate JSON feed
-    
+
     Returns:\n
         restructured data entry
     """
@@ -232,7 +232,7 @@ def process_patient_id(data_entry):
 def scramble_fields(data_entry):
     """
     Scrambles fields in data entry based on configurations
-    
+
     Returns:\n
         data entry structure with scrambled fields
     """
@@ -270,16 +270,16 @@ def hash_fields(data_entry):
 def format_field_keys(data_entry):
     """
     Formats the field names in the data entry
-    
+
     Returns:\n
         data entry structure with formatted field namess
     """
 
     rename_fields = config.country_config.get('rename_fields',
                                               {}).get(data_entry['formId'], {})
-    character_replacements = config.country_config.get('replace_characters', 
+    character_replacements = config.country_config.get('replace_characters',
                                                        {}).get(data_entry['formId'], [])
-    data_fields = data_entry['data'].keys()
+    data_fields = list(data_entry['data'].keys())
 
     # Perform character replacements to all fields
     for characters in character_replacements:


### PR DESCRIPTION
Tis PR fixes a very strange bug where certain field names were not formatted correctly with `/` instead of `:` character replacement. The solution turned out to be:

`dict_keys` objects return by the `.keys()` function is coupled to the dictionary.  Everytime you pop an element from the dictionary, it is popped from corresponding `dict_keys` objects. This resulted in the loop passing over a `dict_keys` object to just completely skip certain keys.

Casting the dict_keys object to a list, before you start to iterate over it breaks the coupling with the dictionary, meaning that when you pop a dictionary key, you don't also change all the indicies of the dict_keys object you're in the middle of iterating over.

Presumably with the way previous forms were designed nothing terrible happened, but this effect is coupled with the order in which keys are popped, so the new form must have had a different arrangement of keys that caused the bug to come to our attention. 